### PR TITLE
Travis: change dist to xenial for sqlite version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 python:
   - "2.7"


### PR DESCRIPTION
fix #31: Django 2.2 enforces sqlite 3.8.3 or greater which is not available on Trusty images, switching to Xenial fixes

