### PR TITLE
Normalize urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## 2.4.2
 ### Fixed
 - peeringdb.client.Client constructor type is too strict (#134)
+- normalize URLs to avoid `//` in URL concatenations
 
 
 ## 2.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 
 ## Unreleased
+### Fixed
+- normalize URLs to avoid `//` in URL concatenations
 
 
 ## 2.4.2
 ### Fixed
 - peeringdb.client.Client constructor type is too strict (#134)
-- normalize URLs to avoid `//` in URL concatenations
 
 
 ## 2.4.1

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,7 +1,6 @@
 Unreleased:
   added: []
   fixed:
-  - peeringdb.client.Client constructor type is too strict (#134)
   - "normalize URLs to avoid `//` in URL concatenations"
   changed: []
   deprecated: []

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,6 +1,8 @@
 Unreleased:
   added: []
-  fixed: []
+  fixed:
+  - peeringdb.client.Client constructor type is too strict (#134)
+  - "normalize URLs to avoid `//` in URL concatenations"
   changed: []
   deprecated: []
   removed: []

--- a/src/peeringdb/fetch.py
+++ b/src/peeringdb/fetch.py
@@ -41,10 +41,11 @@ class Fetcher:
         self.resources: dict[
             str, list[dict[str, Union[str, int, bool, list, dict]]]
         ] = {}
-        self.url: str = url
+        # normalize to avoid `//` in URL concatenations like f"{self.url}/{endpoint}"
+        self.url: str = url.rstrip("/")
         self.timeout: int = timeout or 60
         self.api_key: str = api_key
-        self.cache_url: str = cache_url
+        self.cache_url: str = cache_url.rstrip("/")
         self.cache_dir: str = os.path.expanduser(
             str(kwargs.get("cache_dir", "~/.cache/peeringdb"))
         )

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -24,6 +24,40 @@ def fetcher():
     return Fetcher(**CONFIG_CACHING["sync"])
 
 
+@pytest.mark.parametrize(
+    "url,cache_url,expected_url,expected_cache_url",
+    [
+        (
+            "https://www.peeringdb.com/api",
+            "https://public.peeringdb.com",
+            "https://www.peeringdb.com/api",
+            "https://public.peeringdb.com",
+        ),
+        (
+            "https://www.peeringdb.com/api/",
+            "https://public.peeringdb.com/",
+            "https://www.peeringdb.com/api",
+            "https://public.peeringdb.com",
+        ),
+        (
+            "https://www.peeringdb.com/api///",
+            "https://public.peeringdb.com///",
+            "https://www.peeringdb.com/api",
+            "https://public.peeringdb.com",
+        ),
+        ("", "", "", ""),
+    ],
+)
+def test_fetcher_url_normalization(url, cache_url, expected_url, expected_cache_url):
+    """
+    Trailing slashes on url and cache_url must be stripped so that
+    f"{self.url}/{endpoint}" concatenations don't produce `//`.
+    """
+    fetcher = Fetcher(url=url, timeout=60, cache_url=cache_url)
+    assert fetcher.url == expected_url
+    assert fetcher.cache_url == expected_cache_url
+
+
 @pytest.mark.parametrize("tag", tags)
 @patch("requests.get")
 def test_fetch_cache(mock_get, fetcher, tag):


### PR DESCRIPTION
normalize urls to avoid // in URL concatenations

addresses part of peeringdb/peeringdb#1918